### PR TITLE
fix: missing guard before editing previous log

### DIFF
--- a/dqt/dqt_json.py
+++ b/dqt/dqt_json.py
@@ -528,5 +528,10 @@ class DQTJSON:
             return False
         
         return True
-
+    
+    def no_previous_logs(self) -> bool:
+        """Return whether there are no previous logs (other than today's)."""
+        if len(self.logs) <= 1:
+            return True
+        return False
     

--- a/dqt/tracker.py
+++ b/dqt/tracker.py
@@ -151,6 +151,10 @@ class Tracker:
                     if self.json.no_logs():
                         err("You haven't entered any logs yet!")
                         continue
+                    if self.json.no_previous_logs():
+                        err("You haven't entered any previous logs yet other "
+                            "than today's!")
+                        continue
                     while True:
                         selected_d = self.manager.prompt_prev_date()
                         print(Txt("\nSelected log:").bold())


### PR DESCRIPTION
Previously, if the user had only entered their log for today and tried to edit a previous log, the program did not account for this and let the user select a date. Now the program checks that the length of the logs dict is more than 1 before entering the edit previous log functionality.

Closes #8